### PR TITLE
com.virtualmaker.buildalon 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ These methods can be executed using the `-executeMethod` command line argument t
 "/path/to/Unity.exe" -projectPath "/path/to/unity/project" -quit -batchmode -executeMethod Utilities.Editor.BuildPipeline.UnityPlayerBuildTools.ValidateProject -importTMProEssentialsAsset
 ```
 
+#### Project Validation Command Line Arguments
+
+> [!NOTE]
+> No longer required in Unity 6+
+
+| Argument | Description |
+| -------- | ----------- |
+| `-importTMProEssentialsAsset` | Imports the TMPro Essential assets if they are not already in the project. |
+
+```bash
+"/path/to/Unity.exe" -projectPath "/path/to/unity/project" -quit -batchmode -executeMethod Utilities.Editor.BuildPipeline.UnityPlayerBuildTools.ValidateProject -importTMProEssentialsAsset
+```
+
 ### Additional Custom Command Line Arguments
 
 In addition to any already defined [Unity Editor command line arguments](https://docs.unity3d.com/Manual/EditorCommandLineArguments.html), this plugin offers some additional options:

--- a/README.md
+++ b/README.md
@@ -218,3 +218,14 @@ Works for any Apple Platform Target: MacOS, iOS, tvOS, and visionOS.
 | Argument | Description |
 | -------- | ----------- |
 | `-arch` | Sets the build architecture. Can be: `x64`, `arm64`, or `x64arm64`. |
+
+##### Windows Universal Platform Command Line Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `-arch` | Sets the build architecture. Can be: `x64`, `x86`, `ARM`, or `ARM64`. |
+| `-wsaUWPBuildType` | Sets the output build type when building to Universal Windows Platform. Can be: `XAML`, `D3D`, or `ExecutableOnly`. |
+| `-wsaSetDeviceFamily` | Sets the device family. Can be: `Desktop`, `Mobile`, `Xbox`, `Holographic`, `Team`, `IOT`, or `IoTHeadless`. |
+| `-wsaUWPSDK` | Sets the UWP SDK Version to build for. |
+| `-wsaMinUWPSDK` | Sets the min UWP SDK to build for. |
+| `-wsaCertificate` | Sets the signing certificate. Must pass the path and password together. `-wsaCertificate "path/to/cert.pfx" myP@55w0rd` |

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Documentation~/README.md
@@ -146,6 +146,19 @@ These methods can be executed using the `-executeMethod` command line argument t
 "/path/to/Unity.exe" -projectPath "/path/to/unity/project" -quit -batchmode -executeMethod Utilities.Editor.BuildPipeline.UnityPlayerBuildTools.ValidateProject -importTMProEssentialsAsset
 ```
 
+#### Project Validation Command Line Arguments
+
+> [!NOTE]
+> No longer required in Unity 6+
+
+| Argument | Description |
+| -------- | ----------- |
+| `-importTMProEssentialsAsset` | Imports the TMPro Essential assets if they are not already in the project. |
+
+```bash
+"/path/to/Unity.exe" -projectPath "/path/to/unity/project" -quit -batchmode -executeMethod Utilities.Editor.BuildPipeline.UnityPlayerBuildTools.ValidateProject -importTMProEssentialsAsset
+```
+
 ### Additional Custom Command Line Arguments
 
 In addition to any already defined [Unity Editor command line arguments](https://docs.unity3d.com/Manual/EditorCommandLineArguments.html), this plugin offers some additional options:

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Documentation~/README.md
@@ -218,3 +218,14 @@ Works for any Apple Platform Target: MacOS, iOS, tvOS, and visionOS.
 | Argument | Description |
 | -------- | ----------- |
 | `-arch` | Sets the build architecture. Can be: `x64`, `arm64`, or `x64arm64`. |
+
+##### Windows Universal Platform Command Line Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `-arch` | Sets the build architecture. Can be: `x64`, `x86`, `ARM`, or `ARM64`. |
+| `-wsaUWPBuildType` | Sets the output build type when building to Universal Windows Platform. Can be: `XAML`, `D3D`, or `ExecutableOnly`. |
+| `-wsaSetDeviceFamily` | Sets the device family. Can be: `Desktop`, `Mobile`, `Xbox`, `Holographic`, `Team`, `IOT`, or `IoTHeadless`. |
+| `-wsaUWPSDK` | Sets the UWP SDK Version to build for. |
+| `-wsaMinUWPSDK` | Sets the min UWP SDK to build for. |
+| `-wsaCertificate` | Sets the signing certificate. Must pass the path and password together. `-wsaCertificate "path/to/cert.pfx" myP@55w0rd` |

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/BuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/BuildInfo.cs
@@ -118,13 +118,13 @@ namespace Buildalon.Editor.BuildPipeline
                     case BuildTarget.StandaloneWindows:
                     case BuildTarget.StandaloneWindows64:
 #if PLATFORM_STANDALONE_WIN
-                        return UnityEditor.WindowsStandalone.UserBuildSettings.createSolution ? $"{Path.DirectorySeparatorChar}{Application.productName}" : ".exe";
+                        return UnityEditor.WindowsStandalone.UserBuildSettings.createSolution ? $"{Path.DirectorySeparatorChar}{BundleIdentifier}" : ".exe";
 #else
                         return ".exe";
 #endif
                     case BuildTarget.StandaloneOSX:
 #if PLATFORM_STANDALONE_OSX
-                        return UnityEditor.OSXStandalone.UserBuildSettings.createXcodeProject ? $"{Path.DirectorySeparatorChar}{Application.productName}" : ".app";
+                        return UnityEditor.OSXStandalone.UserBuildSettings.createXcodeProject ? $"{Path.DirectorySeparatorChar}{Application.productName}.xcodeproj" : ".app";
 #else
                         return ".app";
 #endif

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/BuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/BuildInfo.cs
@@ -118,13 +118,13 @@ namespace Buildalon.Editor.BuildPipeline
                     case BuildTarget.StandaloneWindows:
                     case BuildTarget.StandaloneWindows64:
 #if PLATFORM_STANDALONE_WIN
-                        return UnityEditor.WindowsStandalone.UserBuildSettings.createSolution ? $"{Path.DirectorySeparatorChar}{BundleIdentifier}" : ".exe";
+                        return UnityEditor.WindowsStandalone.UserBuildSettings.createSolution ? $"{Path.DirectorySeparatorChar}{Application.productName}" : ".exe";
 #else
                         return ".exe";
 #endif
                     case BuildTarget.StandaloneOSX:
 #if PLATFORM_STANDALONE_OSX
-                        return UnityEditor.OSXStandalone.UserBuildSettings.createXcodeProject ? $"{Path.DirectorySeparatorChar}{Application.productName}.xcodeproj" : ".app";
+                        return UnityEditor.OSXStandalone.UserBuildSettings.createXcodeProject ? $"{Path.DirectorySeparatorChar}{Application.productName}" : ".app";
 #else
                         return ".app";
 #endif

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/IOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/IOSBuildInfo.cs
@@ -15,7 +15,7 @@ namespace Buildalon.Editor.BuildPipeline
         {
             if (EditorUserBuildSettings.activeBuildTarget != BuildTarget) { return; }
 #if PLATFORM_IOS
-#if !UNITY_2021_1_OR_NEWER
+#if !UNITY_2022_1_OR_NEWER
             // https://discussions.unity.com/t/bitcode-bundle-could-not-be-generated-issue/792591/4
             var projectPath = $"{report.summary.outputPath}/Unity-iPhone.xcodeproj/project.pbxproj";
             var pbxProject = new UnityEditor.iOS.Xcode.PBXProject();
@@ -25,14 +25,14 @@ namespace Buildalon.Editor.BuildPipeline
 #else
             var targetName = PBXProject.GetUnityTargetName();
             var targetGuid = pbxProject.TargetGuidByName(targetName);
-#endif
+#endif // UNITY_2019_3_OR_NEWER
             pbxProject.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
             pbxProject.WriteToFile(projectPath);
             var projectInString = System.IO.File.ReadAllText(projectPath);
             projectInString = projectInString.Replace("ENABLE_BITCODE = YES;", "ENABLE_BITCODE = NO;");
             System.IO.File.WriteAllText(projectPath, projectInString);
-#endif
-#endif
+#endif // !UNITY_2022_1_OR_NEWER
+#endif // PLATFORM_IOS
         }
     }
 }

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/IOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/IOSBuildInfo.cs
@@ -16,21 +16,19 @@ namespace Buildalon.Editor.BuildPipeline
             if (EditorUserBuildSettings.activeBuildTarget != BuildTarget) { return; }
 #if PLATFORM_IOS
 #if !UNITY_2021_1_OR_NEWER
-            // https://discussions.unity.com/t/bitcode-bundle-could-not-be-generated-issue/792591/4
+            // https://support.unity.com/hc/en-us/articles/207942813-How-can-I-disable-Bitcode-support
             var projectPath = $"{report.summary.outputPath}/Unity-iPhone.xcodeproj/project.pbxproj";
             var pbxProject = new UnityEditor.iOS.Xcode.PBXProject();
             pbxProject.ReadFromFile(projectPath);
-#if UNITY_2019_3_OR_NEWER
-            var targetGuid = pbxProject.GetUnityMainTargetGuid();
-#else
-            var targetName = PBXProject.GetUnityTargetName();
-            var targetGuid = pbxProject.TargetGuidByName(targetName);
-#endif
-            pbxProject.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
+            var target = pbxProject.GetUnityMainTargetGuid();
+            // ReSharper disable once InconsistentNaming
+            const string ENABLE_BITCODE = nameof(ENABLE_BITCODE);
+            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
+            target = pbxProject.TargetGuidByName(UnityEditor.iOS.Xcode.PBXProject.GetUnityTestTargetName());
+            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
+            target = pbxProject.GetUnityFrameworkTargetGuid();
+            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
             pbxProject.WriteToFile(projectPath);
-            var projectInString = System.IO.File.ReadAllText(projectPath);
-            projectInString = projectInString.Replace("ENABLE_BITCODE = YES;", "ENABLE_BITCODE = NO;");
-            System.IO.File.WriteAllText(projectPath, projectInString);
 #endif
 #endif
         }

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/IOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/IOSBuildInfo.cs
@@ -16,19 +16,21 @@ namespace Buildalon.Editor.BuildPipeline
             if (EditorUserBuildSettings.activeBuildTarget != BuildTarget) { return; }
 #if PLATFORM_IOS
 #if !UNITY_2021_1_OR_NEWER
-            // https://support.unity.com/hc/en-us/articles/207942813-How-can-I-disable-Bitcode-support
+            // https://discussions.unity.com/t/bitcode-bundle-could-not-be-generated-issue/792591/4
             var projectPath = $"{report.summary.outputPath}/Unity-iPhone.xcodeproj/project.pbxproj";
             var pbxProject = new UnityEditor.iOS.Xcode.PBXProject();
             pbxProject.ReadFromFile(projectPath);
-            var target = pbxProject.GetUnityMainTargetGuid();
-            // ReSharper disable once InconsistentNaming
-            const string ENABLE_BITCODE = nameof(ENABLE_BITCODE);
-            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
-            target = pbxProject.TargetGuidByName(UnityEditor.iOS.Xcode.PBXProject.GetUnityTestTargetName());
-            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
-            target = pbxProject.GetUnityFrameworkTargetGuid();
-            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
+#if UNITY_2019_3_OR_NEWER
+            var targetGuid = pbxProject.GetUnityMainTargetGuid();
+#else
+            var targetName = PBXProject.GetUnityTargetName();
+            var targetGuid = pbxProject.TargetGuidByName(targetName);
+#endif
+            pbxProject.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
             pbxProject.WriteToFile(projectPath);
+            var projectInString = System.IO.File.ReadAllText(projectPath);
+            projectInString = projectInString.Replace("ENABLE_BITCODE = YES;", "ENABLE_BITCODE = NO;");
+            System.IO.File.WriteAllText(projectPath, projectInString);
 #endif
 #endif
         }

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/IOSBuildInfo.cs.meta
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/IOSBuildInfo.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {fileID: 2800000, guid: 8ebcc94e9af4e9c41b94981d5b766dd0, type: 3}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/WSAPlayerBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/WSAPlayerBuildInfo.cs
@@ -1,0 +1,103 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Buildalon.Editor.BuildPipeline
+{
+    public class WSAPlayerBuildInfo : BuildInfo
+    {
+        /// <inheritdoc />
+        public override BuildTarget BuildTarget => BuildTarget.WSAPlayer;
+
+        /// <inheritdoc />
+        public override BuildTargetGroup BuildTargetGroup => BuildTargetGroup.WSA;
+
+        /// <inheritdoc />
+        public override string FullOutputPath => OutputDirectory;
+
+        /// <inheritdoc />
+        public override void ParseCommandLineArgs()
+        {
+            base.ParseCommandLineArgs();
+            var arguments = Environment.GetCommandLineArgs();
+
+            for (int i = 0; i < arguments.Length; ++i)
+            {
+                switch (arguments[i])
+                {
+                    case "-arch":
+                        var arch = arguments[++i];
+
+                        if (!string.IsNullOrWhiteSpace(arch))
+                        {
+                            EditorUserBuildSettings.wsaArchitecture = arch;
+                        }
+                        else
+                        {
+                            Debug.LogError($"Failed to parse -arch \"{arguments[i]}\"");
+                        }
+                        break;
+#if !UNITY_2021_1_OR_NEWER
+                    case "-wsaSubtarget":
+                        if (Enum.TryParse<WSASubtarget>(arguments[++i], out var subTarget))
+                        {
+                            EditorUserBuildSettings.wsaSubtarget = subTarget;
+                        }
+                        else
+                        {
+                            Debug.LogError($"Failed to parse -wsaSubtarget \"{arguments[i]}\"");
+                        }
+                        break;
+#endif
+                    case "-wsaUWPBuildType":
+                        if (Enum.TryParse<WSAUWPBuildType>(arguments[++i], out var buildType))
+                        {
+                            EditorUserBuildSettings.wsaUWPBuildType = buildType;
+                        }
+                        else
+                        {
+                            Debug.LogError($"Failed to parse -wsaUWPBuildType \"{arguments[i]}\"");
+                        }
+                        break;
+                    case "-wsaSetDeviceFamily":
+                        if (Enum.TryParse<PlayerSettings.WSATargetFamily>(arguments[++i], out var family))
+                        {
+                            PlayerSettings.WSA.SetTargetDeviceFamily(family, true);
+                        }
+                        else
+                        {
+                            Debug.LogError($"Failed to parse -wsaSetDeviceFamily \"{arguments[i]}\"");
+                        }
+                        break;
+                    case "-wsaUWPSDK":
+                        EditorUserBuildSettings.wsaUWPSDK = arguments[++i];
+                        break;
+                    case "-wsaMinUWPSDK":
+                        EditorUserBuildSettings.wsaMinUWPSDK = arguments[++i];
+                        break;
+                    case "-wsaCertificate":
+                        var path = arguments[++i];
+
+                        if (string.IsNullOrWhiteSpace(path))
+                        {
+                            Debug.LogError("Failed to parse -wsaCertificate. Missing path!");
+                            break;
+                        }
+
+                        var password = arguments[++i];
+
+                        if (string.IsNullOrWhiteSpace(password))
+                        {
+                            Debug.LogError("Failed to parse -wsaCertificate. Missing password!");
+                            break;
+                        }
+
+                        PlayerSettings.WSA.SetCertificate(path, password);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/WSAPlayerBuildInfo.cs.meta
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Platforms/WSAPlayerBuildInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c8082d56f90faa43b4f88aaf8fbbd51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/UnityPlayerBuildTools.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/UnityPlayerBuildTools.cs
@@ -52,34 +52,10 @@ namespace Buildalon.Editor.BuildPipeline
                         case BuildTarget.iOS:
                             buildInfoInstance = new IOSBuildInfo();
                             break;
+                        case BuildTarget.WSAPlayer:
+                            buildInfoInstance = new WSAPlayerBuildInfo();
+                            break;
                         // TODO: Add additional platform specific build info classes as needed
-                        //case BuildTarget.StandaloneWindows:
-                        //case BuildTarget.StandaloneWindows64:
-                        //    break;
-                        //case BuildTarget.WebGL:
-                        //    break;
-                        //case BuildTarget.WSAPlayer:
-                        //    break;
-                        //case BuildTarget.StandaloneLinux64:
-                        //    break;
-                        //case BuildTarget.PS4:
-                        //    break;
-                        //case BuildTarget.XboxOne:
-                        //    break;
-                        //case BuildTarget.tvOS:
-                        //    break;
-                        //case BuildTarget.Switch:
-                        //    break;
-                        //case BuildTarget.Lumin:
-                        //    break;
-                        //case BuildTarget.Stadia:
-                        //    break;
-                        //case BuildTarget.GameCoreXboxOne:
-                        //    break;
-                        //case BuildTarget.PS5:
-                        //    break;
-                        //case BuildTarget.EmbeddedLinux:
-                        //    break;
                         default:
                             buildInfoInstance = new BuildInfo();
                             break;

--- a/Utilities.BuildPipeline/ProjectSettings/ProjectSettings.asset
+++ b/Utilities.BuildPipeline/ProjectSettings/ProjectSettings.asset
@@ -177,6 +177,7 @@ PlayerSettings:
     Android: com.virtualmaker.buildalon
     Lumin: com.virtualmaker.buildalon
     Standalone: com.virtualmaker.buildalon
+    Windows Store Apps: com.virtualmaker.buildalon
     iPhone: com.virtualmaker.buildalon
   buildNumber:
     Standalone: 0
@@ -792,7 +793,7 @@ PlayerSettings:
     Windows Store Apps: 6
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
-  metroPackageName: com.utilties.dummy
+  metroPackageName: com.virtualmaker.buildalon
   metroPackageVersion: 1.0.0.0
   metroCertificatePath:
   metroCertificatePassword:

--- a/Utilities.BuildPipeline/ProjectSettings/ProjectSettings.asset
+++ b/Utilities.BuildPipeline/ProjectSettings/ProjectSettings.asset
@@ -177,6 +177,7 @@ PlayerSettings:
     Android: com.virtualmaker.buildalon
     Lumin: com.virtualmaker.buildalon
     Standalone: com.virtualmaker.buildalon
+    iPhone: com.virtualmaker.buildalon
   buildNumber:
     Standalone: 0
     iPhone: 0


### PR DESCRIPTION
- added WSAPlayerBuildInfo
- added Universal Windows Platform command line args
- added post process build action to disable unsupported ENABLE_BITCODE since it is no longer supported
- change IOSBuildInfo compiler symbol to include 2021 for bitcode disabling
- updated exported standalone directory paths