### PR TITLE
com.virtualmaker.buildalon 1.3.5

### DIFF
--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Logging/CILoggingUtility.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Logging/CILoggingUtility.cs
@@ -52,7 +52,8 @@ namespace Buildalon.Editor.BuildPipeline.Logging
             @"Reference Rewriter found some errors while running with command",
             @"Reference rewriter: Error: method `System.Numerics.Vector3[] Windows.Perception.Spatial.SpatialStageFrameOfReference::TryGetMovementBounds(Windows.Perception.Spatial.SpatialCoordinateSystem)` doesn't exist in target framework. It is referenced from XRTK.WindowsMixedReality.dll at System.Boolean XRTK.WindowsMixedReality.Providers.BoundarySystem.WindowsMixedRealityBoundaryDataProvider::TryGetBoundaryGeometry",
             @"Selected Visual Studio is missing required components and may not be able to build the generated project. You can install the missing Visual Studio components by opening the generated project in Visual Studio.",
-            @"GfxDevice renderer is null. Unity cannot update the Ambient Probe and Reflection Probes that the SkyManager generates. Run the Editor without the -nographics argument or generate lighting for your scene."
+            @"GfxDevice renderer is null. Unity cannot update the Ambient Probe and Reflection Probes that the SkyManager generates. Run the Editor without the -nographics argument or generate lighting for your scene.",
+            @"Light baking could not be started because no valid OpenCL device could be found."
         };
 
         static CILoggingUtility()

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Logging/GitHubActionsLogger.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/Logging/GitHubActionsLogger.cs
@@ -106,9 +106,18 @@ namespace Buildalon.Editor.BuildPipeline.Logging
 
                         if (!hasMessages) { continue; }
 
-                        errorLogs.AddRange(step.messages.Where(message => message.type == LogType.Error || message.type == LogType.Assert || message.type == LogType.Exception));
-                        warningLogs.AddRange(step.messages.Where(message => message.type == LogType.Warning));
-                        infoLogs.AddRange(step.messages.Where(message => message.type == LogType.Log));
+                        errorLogs.AddRange(
+                            step.messages
+                                .Where(message => message.type == LogType.Error || message.type == LogType.Assert || message.type == LogType.Exception)
+                                .Where(message => !CILoggingUtility.IgnoredLogs.Any(message.content.Contains)));
+                        warningLogs.AddRange(
+                            step.messages
+                                .Where(message => message.type == LogType.Warning)
+                                .Where(message => !CILoggingUtility.IgnoredLogs.Any(message.content.Contains)));
+                        infoLogs.AddRange(
+                            step.messages
+                                .Where(message => message.type == LogType.Log)
+                                .Where(message => !CILoggingUtility.IgnoredLogs.Any(message.content.Contains)));
                     }
 
                     string ProcessLogMessage(BuildStepMessage message)

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/package.json
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/package.json
@@ -3,7 +3,7 @@
   "displayName": "Buildalon",
   "description": "Buildalon is a comprehensive suite of automation tools to help Unity developers build, test, and deploy their projects faster.",
   "keywords": [],
-  "version": "1.3.4",
+  "version": "1.3.5",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/buildalon/com.virtualmaker.buildalon#documentation",
   "changelogUrl": "https://github.com/buildalon/com.virtualmaker.buildalon/releases",


### PR DESCRIPTION
- added "Light baking could not be started because no valid OpenCL device could be found." to ignored logs
- filter logs in build summary