### PR TITLE
Add productName build argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-versionName` | Sets the version of the application. Value must be string. |
 | `-buildNumber` | Sets the version build number of the application. (For Android, this must be an integer.) |
 | `-bundleIdentifier` | Sets the bundle identifier of the application. |
+| `-productName` | Sets the product name and generated build artifact name. By default, build artifact names continue to use the bundle identifier. |
 | `-sceneList` | Sets the scenes of the application, list as CSV. |
 | `-sceneListFile` | Sets the scenes of the application, list as JSON. |
 | `-buildOutputDirectory` | Sets the output directory for the build. |

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Documentation~/README.md
@@ -157,6 +157,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-versionName` | Sets the version of the application. Value must be string. |
 | `-buildNumber` | Sets the version build number of the application. (For Android, this must be an integer.) |
 | `-bundleIdentifier` | Sets the bundle identifier of the application. |
+| `-productName` | Sets the product name and generated build artifact name. By default, build artifact names continue to use the bundle identifier. |
 | `-sceneList` | Sets the scenes of the application, list as CSV. |
 | `-sceneListFile` | Sets the scenes of the application, list as JSON. |
 | `-buildOutputDirectory` | Sets the output directory for the build. |

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/BuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/BuildInfo.cs
@@ -44,6 +44,31 @@ namespace Buildalon.Editor.BuildPipeline
             }
         }
 
+        private string productName;
+        private bool productNameOverride;
+
+        /// <inheritdoc />
+        public string ProductName
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(productName))
+                {
+                    productName = PlayerSettings.productName;
+                }
+
+                return productName;
+            }
+            set
+            {
+                productName = value;
+                productNameOverride = true;
+                PlayerSettings.productName = productName;
+            }
+        }
+
+        private string OutputName => productNameOverride ? ProductName : BundleIdentifier;
+
         /// <inheritdoc />
         public virtual Version Version { get; set; }
 
@@ -110,7 +135,7 @@ namespace Buildalon.Editor.BuildPipeline
         }
 
         /// <inheritdoc />
-        public virtual string FullOutputPath => $"{OutputDirectory}{Path.DirectorySeparatorChar}{BundleIdentifier}{ExecutableFileExtension}";
+        public virtual string FullOutputPath => $"{OutputDirectory}{Path.DirectorySeparatorChar}{OutputName}{ExecutableFileExtension}";
 
         /// <inheritdoc />
         public virtual string ExecutableFileExtension
@@ -122,13 +147,13 @@ namespace Buildalon.Editor.BuildPipeline
                     case BuildTarget.StandaloneWindows:
                     case BuildTarget.StandaloneWindows64:
 #if PLATFORM_STANDALONE_WIN
-                        return UnityEditor.WindowsStandalone.UserBuildSettings.createSolution ? $"{Path.DirectorySeparatorChar}{Application.productName}" : ".exe";
+                        return UnityEditor.WindowsStandalone.UserBuildSettings.createSolution ? $"{Path.DirectorySeparatorChar}{ProductName}" : ".exe";
 #else
                         return ".exe";
 #endif
                     case BuildTarget.StandaloneOSX:
 #if PLATFORM_STANDALONE_OSX
-                        return UnityEditor.OSXStandalone.UserBuildSettings.createXcodeProject ? $"{Path.DirectorySeparatorChar}{Application.productName}" : ".app";
+                        return UnityEditor.OSXStandalone.UserBuildSettings.createXcodeProject ? $"{Path.DirectorySeparatorChar}{ProductName}" : ".app";
 #else
                         return ".app";
 #endif
@@ -203,6 +228,9 @@ namespace Buildalon.Editor.BuildPipeline
                         break;
                     case "-bundleIdentifier":
                         BundleIdentifier = arguments[++i];
+                        break;
+                    case "-productName":
+                        ProductName = arguments[++i];
                         break;
                     case "-sceneList":
                         Scenes = UnityPlayerBuildTools.SplitSceneList(arguments[++i]);

--- a/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/IBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.virtualmaker.buildalon/Editor/IBuildInfo.cs
@@ -27,6 +27,11 @@ namespace Buildalon.Editor.BuildPipeline
         string BundleIdentifier { get; set; }
 
         /// <summary>
+        /// The product name used by Unity and, when explicitly set, for generated build artifact names.
+        /// </summary>
+        string ProductName { get; set; }
+
+        /// <summary>
         /// The build version number.
         /// </summary>
         /// <remarks>
@@ -120,6 +125,7 @@ namespace Buildalon.Editor.BuildPipeline
         /// -versionName "0.1.0"<para/>
         /// -versionCode "1"<para/>
         /// -bundleIdentifier "com.xrtk.core"<para/>
+        /// -productName "My Product"<para/>
         /// -sceneList (CSV format)<para/>
         /// -sceneListFile (CSV format)<para/>
         /// -buildOutputDirectory <para/>


### PR DESCRIPTION
## Summary
- add a cross-platform -productName command-line argument
- set PlayerSettings.productName when provided
- use the product name for generated build artifact paths only when -productName is explicitly provided, preserving existing bundle-id artifact naming by default
- document the new argument in both README copies

## Testing
- git diff --check